### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/app/components/workbench/Preview.tsx
+++ b/app/components/workbench/Preview.tsx
@@ -1,5 +1,6 @@
 import { useStore } from '@nanostores/react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import DOMPurify from 'dompurify';
 import { IconButton } from '~/components/ui/IconButton';
 import { workbenchStore } from '~/lib/stores/workbench';
 import { PortDropdown } from './PortDropdown';
@@ -92,7 +93,8 @@ export const Preview = memo(() => {
             }}
             onKeyDown={(event) => {
               if (event.key === 'Enter' && validateUrl(url)) {
-                setIframeUrl(url);
+                const sanitizedUrl = DOMPurify.sanitize(url);
+                setIframeUrl(sanitizedUrl);
 
                 if (inputRef.current) {
                   inputRef.current.blur();

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "remix-utils": "^7.6.0",
     "sass-embedded": "^1.81.0",
     "shiki": "^1.9.1",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit": "^5.0.0",
+    "dompurify": "^3.2.1"
   },
   "devDependencies": {
     "@blitz/eslint-plugin": "0.1.0",


### PR DESCRIPTION
Fixes [https://github.com/Bolt-CE/bolt/security/code-scanning/1](https://github.com/Bolt-CE/bolt/security/code-scanning/1)

To fix the problem, we need to ensure that the URL set as the `iframe`'s `src` attribute is properly sanitized to prevent XSS attacks. This can be achieved by using a library like `DOMPurify` to sanitize the URL before setting it. Additionally, we should ensure that the `validateUrl` function is robust and correctly implemented.

1. Install the `DOMPurify` library to sanitize the URL.
2. Import `DOMPurify` in the file.
3. Use `DOMPurify` to sanitize the URL before setting it as the `iframeUrl`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
